### PR TITLE
dps: how to configure mutliple hubs

### DIFF
--- a/content/en/docs/configuration/device-provisioning-service.md
+++ b/content/en/docs/configuration/device-provisioning-service.md
@@ -134,7 +134,7 @@ Defines configuration of the plgd hub where the device connects after it's succe
 | `enrollmentGroups.[].hub.caPool` | string | `File path to the root certificate in PEM format. Multiple certificates in a single file are supported.` |  `""` |
 | `enrollmentGroups.[].hub.hubID` | string | `Uniqhe id of the plgd hub instance.` |  `""` |
 | `enrollmentGroups.[].hub.coapGateway` | string | `plgd hub CoAP gateway endpoint where the devices should connect to after successful provisioning.Format <IP:PORT>.` |  `""` |
-| `enrollmentGroups.[].hub.gateways` | []string | `plgd hub gateway multiple endpoints where the devices should connect to after successful provisioning. Format <SCHEME>://<IP:PORT>, for example coaps+tcp://plgd.cloud:1234` |  `""` |
+| `enrollmentGroups.[].hub.gateways` | []string | `plgd hub gateway multiple endpoints where the devices should connect to after successful provisioning. Format <SCHEME>://<IP:PORT>, for example coaps+tcp://plgd.cloud:1234` |  `[]` |
 | `enrollmentGroups.[].hub.certificateAuthority.grpc.address` | string | `plgd hub Certificate Authority endpoint used to sign device identity CSRs. Format <IP:PORT>.` |  `""` |
 | `enrollmentGroups.[].hub.certificateAuthority.grpc.keepAlive.time` | string | `After a duration of this time if the client doesn't see any activity it pings the server to see if the transport is still alive.` | `10s` |
 | `enrollmentGroups.[].hub.certificateAuthority.grpc.keepAlive.timeout` | string | `After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed.` | `20s` |

--- a/content/en/docs/configuration/device-provisioning-service.md
+++ b/content/en/docs/configuration/device-provisioning-service.md
@@ -134,7 +134,7 @@ Defines configuration of the plgd hub where the device connects after it's succe
 | `enrollmentGroups.[].hub.caPool` | string | `File path to the root certificate in PEM format. Multiple certificates in a single file are supported.` |  `""` |
 | `enrollmentGroups.[].hub.hubID` | string | `Uniqhe id of the plgd hub instance.` |  `""` |
 | `enrollmentGroups.[].hub.coapGateway` | string | `plgd hub CoAP gateway endpoint where the devices should connect to after successful provisioning.Format <IP:PORT>.` |  `""` |
-| `enrollmentGroups.[].hub.gateways` | []string | `plgd hub gateway multiple endpoints where the devices should connect to after successful provisioning. Format <SCHEME>://<IP:PORT>, for example coaps+tcp://plgd.cloud:1234` |  `[]` |
+| `enrollmentGroups.[].hub.gateways` | []string | `plgd hub gateway multiple endpoints where the devices should connect to after successful provisioning. If coapGateway is also set, it is prepended before .gateways. Format <SCHEME>://<IP:PORT>, for example coaps+tcp://plgd.cloud:1234` |  `[]` |
 | `enrollmentGroups.[].hub.certificateAuthority.grpc.address` | string | `plgd hub Certificate Authority endpoint used to sign device identity CSRs. Format <IP:PORT>.` |  `""` |
 | `enrollmentGroups.[].hub.certificateAuthority.grpc.keepAlive.time` | string | `After a duration of this time if the client doesn't see any activity it pings the server to see if the transport is still alive.` | `10s` |
 | `enrollmentGroups.[].hub.certificateAuthority.grpc.keepAlive.timeout` | string | `After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed.` | `20s` |

--- a/content/en/docs/configuration/device-provisioning-service.md
+++ b/content/en/docs/configuration/device-provisioning-service.md
@@ -122,6 +122,8 @@ Enrollment group entry configuration.
 | `enrollmentGroups.[].preSharedKeyFile` | string | `File path to the pre-shared key that will be stored on the device for the owner. It must be empty or have 16 characters in the preSharedKeyFile.` | `""` |
 | `enrollmentGroups.[].attestationMechanism.x509.certificateChain` | string | `File path to certificate chain in PEM format.` | `""` |
 | `enrollmentGroups.[].attestationMechanism.x509.expiredCertificateEnabled` | bool | `Accept device connections with an expired certificate.` | `false` |
+| `enrollmentGroups.[].Hub` | object | `Defines configuration of the plgd hub where the device connects after it's successfully provisioned.` | `{}` |
+| `enrollmentGroups.[].Hubs` | []object | `Defines configuration of the multiple plgd hubs where the device connects after it's successfully provisioned.` | `[]` |
 
 #### Hub
 
@@ -132,6 +134,7 @@ Defines configuration of the plgd hub where the device connects after it's succe
 | `enrollmentGroups.[].hub.caPool` | string | `File path to the root certificate in PEM format. Multiple certificates in a single file are supported.` |  `""` |
 | `enrollmentGroups.[].hub.hubID` | string | `Uniqhe id of the plgd hub instance.` |  `""` |
 | `enrollmentGroups.[].hub.coapGateway` | string | `plgd hub CoAP gateway endpoint where the devices should connect to after successful provisioning.Format <IP:PORT>.` |  `""` |
+| `enrollmentGroups.[].hub.gateways` | []string | `plgd hub gateway multiple endpoints where the devices should connect to after successful provisioning. Format <SCHEME>://<IP:PORT>, for example coaps+tcp://plgd.cloud:1234` |  `""` |
 | `enrollmentGroups.[].hub.certificateAuthority.grpc.address` | string | `plgd hub Certificate Authority endpoint used to sign device identity CSRs. Format <IP:PORT>.` |  `""` |
 | `enrollmentGroups.[].hub.certificateAuthority.grpc.keepAlive.time` | string | `After a duration of this time if the client doesn't see any activity it pings the server to see if the transport is still alive.` | `10s` |
 | `enrollmentGroups.[].hub.certificateAuthority.grpc.keepAlive.timeout` | string | `After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed.` | `20s` |

--- a/content/en/docs/services/device-provisioning-service/device-provisioning-service.md
+++ b/content/en/docs/services/device-provisioning-service/device-provisioning-service.md
@@ -104,3 +104,17 @@ Step number 4 and 9 are optional.
 9. Device provisioning doesn't require to connect the device to the plgd hub. In such a case, device is ready to be securely used for your Device-to-Device scenarios.
 
 {{< /note >}}
+
+### Multiple PLGD Hubs
+
+The DPS supports multiple PLGD hubs or CoAP gateways. This feature enables users to configure multiple PLGD hubs or CoAP gateways for the device through enrollment group configuration.
+
+To configure multiple CoAP gateways, set the helm value `.enrollmentGroups.[].hub.gateways` to the list of CoAP gateways in the format `SCHEME://HOST:PORT`. For example, `[ "coaps+tcp://plgd.cloud:5684", ... ]`.
+
+To set multiple PLGD hubs, set the helm value `.enrollmentGroups.[].hubs` to the list of PLGD hub objects, which contain the same values as the `.enrollmentGroups.[].hub` object in the enrollment group configuration.
+
+{{< note >}}
+
+For multiple hubs, it is expected that the hubs are different instances.
+
+{{< /note >}}

--- a/content/en/docs/services/device-provisioning-service/device-provisioning-service.md
+++ b/content/en/docs/services/device-provisioning-service/device-provisioning-service.md
@@ -107,7 +107,7 @@ Step number 4 and 9 are optional.
 
 ### Multiple PLGD Hubs
 
-The DPS supports multiple PLGD hubs or CoAP gateways. This feature enables users to configure multiple PLGD hubs or CoAP gateways for the device through enrollment group configuration.
+The DPS supports multiple PLGD Hubs or CoAP Gateways. This feature enables users to configure multiple PLGD hubs or CoAP gateways for the device through enrollment group configuration.
 
 To configure multiple CoAP gateways, set the helm value `.enrollmentGroups.[].hub.gateways` to the list of CoAP gateways in the format `SCHEME://HOST:PORT`. For example, `[ "coaps+tcp://plgd.cloud:5684", ... ]`.
 

--- a/content/en/docs/services/device-provisioning-service/features.md
+++ b/content/en/docs/services/device-provisioning-service/features.md
@@ -16,6 +16,7 @@ weight: 2
 - **&#x2611; Rotate device certificates:** This feature allows for the [rotation of device certificates](/docs/services/device-provisioning-service/client-library#certificate-renewal), enhancing security and maintaining up-to-date certificates.
 - **&#x2611; HTTP API to configure access devices:** This feature provides an HTTP API that allows users to configure the enrollment groups.
 - **&#x2611; HTTP API to get provisioned configuration to the devices:** This feature offers an HTTP API to retrieve provisioned configurations of the devices.
+- **&#x2611; Multiple plgd hubs:** This feature enables users to configure multiple PLGD hubs or CoAP gateways for the device.
 
 ### Planned features
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Enhanced support for configuring multiple PLGD hubs or CoAP gateways in the Device Provisioning Service, offering diverse connectivity options for devices post-provisioning.
    - Introduced new configuration options under `enrollmentGroups` to define connection endpoints for devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->